### PR TITLE
Update complete_multipart tests

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -5824,8 +5824,6 @@ def test_multipart_upload_small():
     response = client.complete_multipart_upload(Bucket=bucket_name, Key=key1, UploadId=upload_id, MultipartUpload={'Parts': parts})
     response = client.get_object(Bucket=bucket_name, Key=key1)
     assert response['ContentLength'] == objlen
-    # check extra client.complete_multipart_upload
-    response = client.complete_multipart_upload(Bucket=bucket_name, Key=key1, UploadId=upload_id, MultipartUpload={'Parts': parts})
 
 def _create_key_with_random_content(keyname, size=7*1024*1024, bucket_name=None, client=None):
     if bucket_name is None:
@@ -6024,8 +6022,6 @@ def test_multipart_upload():
     client = get_client()
 
     (upload_id, data, parts) = _multipart_upload(bucket_name=bucket_name, key=key, size=objlen, content_type=content_type, metadata=metadata)
-    client.complete_multipart_upload(Bucket=bucket_name, Key=key, UploadId=upload_id, MultipartUpload={'Parts': parts})
-    # check extra client.complete_multipart_upload
     client.complete_multipart_upload(Bucket=bucket_name, Key=key, UploadId=upload_id, MultipartUpload={'Parts': parts})
 
     response = client.list_objects_v2(Bucket=bucket_name, Prefix=key)


### PR DESCRIPTION
The complete_multipart tests tested Ceph behavior implemented in https://github.com/ceph/ceph/pull/40594. The complete_multipart operation was performed twice. The second call doesn't throw an error on Ceph, but it is supposed to throw 404 in S3. I have updated the tests to remove the second call to complete_multipart.